### PR TITLE
Added Zenodo badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # gcamfd: Calculate food demand using the Edmonds et. al. model
 [![Travis build status](https://travis-ci.org/JGCRI/food-demand.svg?branch=master)](https://travis-ci.org/JGCRI/food-demand)
-[![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/JGCRI/food-demand?branch=master&svg=true)](https://ci.appveyor.com/project/JGCRI/food-demand) 
+[![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/JGCRI/food-demand?branch=master&svg=true)](https://ci.appveyor.com/project/JGCRI/food-demand)
+[![DOI](https://zenodo.org/badge/69679416.svg)](https://zenodo.org/badge/latestdoi/69679416)
+
 
 The Edmonds model divides food consumption into two categories,
 _staples_, which represent basic foodstuffs, and _nonstaples_,
@@ -30,5 +32,5 @@ rslt <- food.dmnd(ps, pn, y, samp.params)
 ```
 Note that the  are parameters available in the folder parameter_data/parameter_data.csv
 
-The parameters can be re-calculated using the Calcute_parameters.R script. 
+The parameters can be re-calculated using the Calcute_parameters.R script.
 The input data can be recalculated using the script Process_Demand_Data.R


### PR DESCRIPTION
Added Zenodo badge to the `README.md` file in the root directory.  

I also released an associated version that is detailed here:  https://github.com/JGCRI/food-demand/releases/tag/v1.2.0

The release of v1.2.0 also includes the `paper1` directory which represents the code used to run and create the data and figures for:

Edmonds J.A., R.P. Link, S.T. Waldhoff, and Y. Cui. 2017. "A Global Food Demand Model for the Assessment of Complex Human-Earth Systems." Climate Change Economics 8, no. 4:Article No. 1750012. PNNL-SA-121534. doi:10.1142/S2010007817500129

Now that the `paper1` directory has been archived, it will be removed in future versions (See #6 )

Resolves #2 
